### PR TITLE
Docs: add `Template Maintenance` and `Patterns` sections

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,8 @@ defined in the template just once and then regularly be synced onto your
 projects.
 
 
+.. _how_it_works:
+
 How it works
 ------------
 

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -186,3 +186,125 @@ Built-in Cookiecutter Context Types
 
 .. autoclass:: scaraplate.cookiecutter.SetupCfg
    :show-inheritance:
+
+
+Template Maintenance
+--------------------
+
+Given that scaraplate provides ability to update the already created
+projects from the updated templates, it's worth discussing the maintenance
+of a scaraplate template.
+
+Removing a template variable
+++++++++++++++++++++++++++++
+
+Template variables could be used as :ref:`feature flags <feature_flags>`
+to gradually introduce some changes in the templates which some target
+projects might not use (yet) by disabling the flag.
+
+But once the migration is complete, you might want to remove the no longer
+needed variable.
+
+Fortunately this is very simple: just stop using it in the template and
+remove it from ``cookiecutter.json``. On the next ``scaraplate rollup``
+the removed variable will be automatically removed from
+the :ref:`cookiecutter context file <cookiecutter_context_types>`.
+
+Adding a new template variable
+++++++++++++++++++++++++++++++
+
+The process for adding a new variable is the same as for removing one:
+just add it to the ``cookiecutter.json`` and you can start using it in
+the template.
+
+If the next ``scaraplate rollup`` is run with ``--no-input``, the new
+variable will have the default value as specified in ``cookiecutter.json``.
+If you need a different value, you have 2 options:
+
+1. Run ``scraplate rollup`` without the ``--no-input`` flag so the value
+   for the new variable could be asked interactively.
+2. Manually add the value to
+   the :ref:`cookiecutter context section <cookiecutter_context_types>`
+   so the next ``rollup`` could pick it up.
+
+Restructuring files
++++++++++++++++++++
+
+Scaraplate strategies intentionally don't provide support for anything
+more complex than a simple file-to-file change. It means that a scaraplate
+template cannot:
+
+1. Delete or move files in the target project;
+2. Take multiple files and union them.
+
+The reason is simple: such operations are always the one-time ones so it
+is just easier to perform them manually once than to maintain that logic
+in the template.
+
+
+Patterns
+--------
+
+This section contains some patterns which might be helpful for
+creating and maintaining a scaraplate template.
+
+.. _feature_flags:
+
+Feature flags
++++++++++++++
+
+Let's say you have a template which you have applied to dozens of your
+projects.
+
+And now you want to start gradually introducing a new feature, let it
+be a new linter.
+
+You probably would not want to start using the new thing everywhere at once.
+Instead, usually you start with one or two projects, gain experience
+and then start rolling it up on the other projects.
+
+For that you can use template variables as feature flags.
+The :ref:`example template <scaraplate_example_template>` contains
+a ``mypy_enabled`` variable which demonstrates this concept. Basically
+it is a regular cookiecutter variable, which can take different values
+in the target projects and thus affect the template by enabling or disabling
+the new feature.
+
+Include files
++++++++++++++
+
+Consider ``Makefile``. On one hand, you would definitely want to have some
+make targets to come from the template; on the other hand, you might need
+to introduce custom make targets in some projects. Coming up with a scaraplate
+strategy which could merge such a file would be quite difficult.
+
+Fortunately, ``Makefile`` allows to include other files. So the solution
+is quite trivial: have ``Makefile`` synced from the template (with
+the :class:`scaraplate.strategies.Overwrite` strategy), and include
+a ``Makefile.inc`` file from there which will not be overwritten by the template.
+This concept is demonstrated in the :ref:`example template <scaraplate_example_template>`.
+
+Manual merging
+++++++++++++++
+
+Sometimes you need to merge some files which might be modified in the target
+projects and for which there's no suitable strategy yet. In this case
+you can use :class:`scaraplate.strategies.TemplateHash` strategy as
+a temporary solution: it would overwrite the file each time a new
+git commit is added to the template, but keep the file unchanged since
+the last rollup of the same template commit.
+
+The :ref:`example template <scaraplate_example_template>` uses this
+approach for ``setup.py``.
+
+Create files conditionally
+++++++++++++++++++++++++++
+
+:doc:`Cookiecutter hooks <cookiecutter_rtd:advanced/hooks>` can be used
+to post-process the generated :ref:`temporary project <how_it_works>`.
+For example, you might want to skip some files from the template
+depending on the variables.
+
+The :ref:`example template <scaraplate_example_template>` contains
+an example hook which deletes ``mypy.ini`` file when the ``mypy_enabled``
+variable is not set to ``1``.


### PR DESCRIPTION
This PR adds new sections to the Scaraplate Template doc page which discuss the template maintenance.

This branch is deployed here: https://scaraplate.readthedocs.io/en/add-template-patterns-doc/template.html#template-maintenance