### PR TITLE
Add support for extra_context to cli (like in `cookiecutter` command)

### DIFF
--- a/src/scaraplate/__main__.py
+++ b/src/scaraplate/__main__.py
@@ -1,6 +1,24 @@
+import collections
+from typing import Mapping
+
 import click
 
 from scaraplate.rollup import rollup as _rollup
+
+
+def validate_extra_context(ctx, param, value):
+    """Validate extra context."""
+    # vendored from https://github.com/cookiecutter/cookiecutter/blob/673f773bfaf591b056d977c4ab82b45d90dce11e/cookiecutter/cli.py#L35-L46  # noqa
+    for s in value:
+        if "=" not in s:
+            raise click.BadParameter(
+                "EXTRA_CONTEXT should contain items of the form key=value; "
+                "'{}' doesn't match that form".format(s)
+            )
+
+    # Convert tuple -- e.g.: (u'program_name=foobar', u'startsecs=66')
+    # to dict -- e.g.: {'program_name': 'foobar', 'startsecs': '66'}
+    return collections.OrderedDict(s.split("=", 1) for s in value) or None
 
 
 @click.group()
@@ -12,6 +30,7 @@ def main():
 @main.command()
 @click.argument("template_dir", type=click.Path(exists=True, file_okay=False))
 @click.argument("target_project_dir", type=click.Path(file_okay=False))
+@click.argument("extra_context", nargs=-1, callback=validate_extra_context)
 @click.option(
     "--no-input",
     is_flag=True,
@@ -21,7 +40,13 @@ def main():
         "in the TEMPLATE_DIR."
     ),
 )
-def rollup(template_dir: str, target_project_dir: str, no_input: bool) -> None:
+def rollup(
+    *,
+    template_dir: str,
+    target_project_dir: str,
+    no_input: bool,
+    extra_context: Mapping[str, str],
+) -> None:
     """Rollup (apply) the cookiecutter template.
 
     The template from TEMPLATE_DIR is applied on top of TARGET_PROJECT_DIR.
@@ -34,11 +59,15 @@ def rollup(template_dir: str, target_project_dir: str, no_input: bool) -> None:
     TARGET_PROJECT_DIR should point to the directory where the template
     should be applied. Might not exist -- it will be created then.
     For monorepos this should point to the subproject inside the monorepo.
+
+    EXTRA_CONTEXT is a list of `key=value` pairs, just like in
+    `cookiecutter` command.
     """
     _rollup(
         template_dir=template_dir,
         target_project_dir=target_project_dir,
         no_input=no_input,
+        extra_context=extra_context,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,41 @@
+from unittest.mock import patch
+
 from click.testing import CliRunner
 
+import scaraplate.__main__ as main_module
 from scaraplate.__main__ import main
 
 
 def test_help():
     runner = CliRunner()
     result = runner.invoke(main, ["--help"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
 
 
 def test_rollup_help():
     runner = CliRunner()
     result = runner.invoke(main, ["rollup", "--help"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
+
+
+def test_extra_context():
+    with patch.object(main_module, "_rollup") as mock_rollup:
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["rollup", ".", "mydest", "key1=value1", "key2=value2"]
+        )
+        assert result.exit_code == 0, result.output
+
+        assert mock_rollup.call_count == 1
+        _, kwargs = mock_rollup.call_args
+        assert kwargs["extra_context"] == {"key1": "value1", "key2": "value2"}
+
+
+def test_extra_context_incorrect():
+    with patch.object(main_module, "_rollup"):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rollup", ".", "mydest", "key1value1"])
+        assert result.exit_code == 2, result.output
+        assert (
+            "EXTRA_CONTEXT should contain items of the form key=value" in result.output
+        )


### PR DESCRIPTION
This PR adds ability to specify variables as CLI arguments non-interactively.

This feature has been mentioned a couple of times:
- https://github.com/rambler-digital-solutions/scaraplate/issues/8#issuecomment-533828259
- https://github.com/rambler-digital-solutions/scaraplate/pull/4#discussion_r312591768

Also it would be useful to have it in https://github.com/rambler-digital-solutions/scaraplate-example-template which does the initial rollup non-interactively.

The following patch shows the usage of this feature (and it will land in scaraplate-example-template as soon as scaraplate 0.2 will be released on pypi):
```patch
diff --git a/Makefile b/Makefile
index fa2a147..f07abd0 100644
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ SHELL := /bin/bash
 .PHONY: test
 test:
        rm -Rf generated_project
-       scaraplate rollup . generated_project --no-input
+       scaraplate rollup . generated_project --no-input \
+               metadata_author=scaraplate-tests \
+               metadata_author_email=um@rambler-co.ru \
+               metadata_description=test
        { \
                set -e; \
                cd generated_project; \
```