### PR TITLE
Add automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 # target: develop - Install package in editable mode with `develop` extras
 develop:
 	@${PYTHON} -m pip install --upgrade pip setuptools wheel
-	@${PYTHON} -m pip install -e .[develop]
+	@${PYTHON} -m pip install -e .[develop,gitlab]
 
 
 .PHONY: dist

--- a/docs/automation.rst
+++ b/docs/automation.rst
@@ -1,0 +1,148 @@
+Rollup Automation
+=================
+
+Once you get comfortable with manual rollups, you might want to set up
+regularly executed automated rollups.
+
+At this moment scaraplate doesn't provide a CLI for that, but there's
+a quite extensible Python code which simplifies implementation of custom
+scenarios.
+
+Supported automation scenarios
+------------------------------
+
+GitLab Merge Request
+++++++++++++++++++++
+
+GitLab integration requires `python-gitlab <https://python-gitlab.readthedocs.io>`_
+package, which can be installed with:
+
+::
+
+    pip install 'scaraplate[gitlab]'
+
+
+Sample ``rollup.py`` script:
+
+::
+
+    from scaraplate import automatic_rollup
+    from scaraplate.automation.gitlab import (
+        GitLabCloneTemplateVCS,
+        GitLabMRProjectVCS,
+    )
+
+
+    automatic_rollup(
+        template_vcs_ctx=GitLabCloneTemplateVCS.clone(
+            project_url="https://mygitlab.example.org/myorg/mytemplate",
+            private_token="your_access_token",
+            clone_ref="master",
+        ),
+        project_vcs_ctx=GitLabMRProjectVCS.clone(
+            gitlab_url="https://mygitlab.example.org",
+            full_project_name="myorg/mytargetproject",
+            private_token="your_access_token",
+            changes_branch="scheduled-template-update",
+            clone_ref="master",
+        ),
+    )
+
+
+This script would do the following:
+
+1. ``git clone`` the template repo to a tempdir;
+2. ``git clone`` the project repo to a tempdir;
+3. Run ``scaraplate rollup ... --no-input``;
+4. Would do nothing if rollup didn't change anything; otherwise it would
+   create a commit with the changes, push it to the ``scheduled-template-update``
+   branch and open a GitLab Merge Request from this branch.
+
+If a MR already exists, :class:`~scaraplate.automation.gitlab.GitLabMRProjectVCS`
+does the following:
+
+1. A one-commit git diff is compared between the already existing MR's branch
+   and the locally committed branch (in a tempdir). If diffs are equal,
+   nothing is done.
+2. If diffs are different, the existing MR's branch is removed from the remote,
+   effectively closing the old MR, and a new branch is pushed, which
+   is followed by creation of a new MR.
+
+To have this script run daily, crontab can be used. Assuming that the script
+is located at ``/opt/rollup.py`` and the desired time for execution is 9:00,
+it might look like this:
+
+::
+
+    $ crontab -e
+    # Add the following line:
+    00 9 * * *  python3 /opt/rollup.py
+
+
+Git push
+++++++++
+
+:class:`~scaraplate.automation.gitlab.GitLabCloneTemplateVCS` and
+:class:`~scaraplate.automation.gitlab.GitLabMRProjectVCS` are based off
+:class:`~scaraplate.automation.git.GitCloneTemplateVCS` and
+:class:`~scaraplate.automation.git.GitCloneProjectVCS`
+correspondingly. GitLab classes add GitLab-specific git-clone URL
+generation and Merge Request creation. The rest (git clone, commit, push)
+is done in the :class:`~scaraplate.automation.git.GitCloneTemplateVCS`
+and :class:`~scaraplate.automation.git.GitCloneProjectVCS` classes.
+
+:class:`~scaraplate.automation.git.GitCloneTemplateVCS` and
+:class:`~scaraplate.automation.git.GitCloneProjectVCS` classes work
+with any git remote. If you're okay with just pushing a branch with
+updates (without opening a Merge Request/Pull Request), then you can
+use the following:
+
+Sample ``rollup.py`` script:
+
+::
+
+    from scaraplate import automatic_rollup, GitCloneProjectVCS, GitCloneTemplateVCS
+
+
+    automatic_rollup(
+        template_vcs_ctx=GitCloneTemplateVCS.clone(
+            clone_url="https://github.com/rambler-digital-solutions/scaraplate-example-template.git",
+            clone_ref="master",
+        ),
+        project_vcs_ctx=GitCloneProjectVCS.clone(
+            clone_url="https://mygit.example.org/myrepo.git",
+            clone_ref="master",
+            changes_branch="scheduled-template-update",
+            commit_author="scaraplate <yourorg@yourcompany>",
+        ),
+    )
+
+
+Python API
+----------
+
+.. autofunction:: scaraplate.automation.base.automatic_rollup
+
+.. autoclass:: scaraplate.automation.base.TemplateVCS
+   :show-inheritance:
+   :members:
+
+.. autoclass:: scaraplate.automation.base.ProjectVCS
+   :show-inheritance:
+   :members:
+
+.. autoclass:: scaraplate.automation.git.GitCloneTemplateVCS
+   :show-inheritance:
+   :members: clone
+
+.. autoclass:: scaraplate.automation.git.GitCloneProjectVCS
+   :show-inheritance:
+   :members: clone
+
+.. autoclass:: scaraplate.automation.gitlab.GitLabCloneTemplateVCS
+   :show-inheritance:
+   :members: clone
+
+.. autoclass:: scaraplate.automation.gitlab.GitLabMRProjectVCS
+   :show-inheritance:
+   :members: clone

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,12 +62,14 @@ scaraplate in the target project.
 The key component of scaraplate are the `strategies`.
 
 Note that none of the strategies use git history or any git-like
-merging. In fact, scaraplate makes no assumptions about the code
-versioning system used by the target project.
+merging. In fact, scaraplate strategies make no assumptions about
+the code versioning system used by the target project.
 Instead, the merging between the files is defined solely by `strategies`
 which generate the output based on the two files and the settings in
 the ``scaraplate.yaml``.
 
+Scaraplate is quite extensible. Many parts are replaceable with custom
+implementations in Python.
 
 Quickstart
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ artifacts building tend to greatly vary between the projects.
 Once described in the template which is easy to rollup onto the specific
 projects, projects unification becomes a trivial task.  Everything can be
 defined in the template just once and then regularly be synced onto your
-projects.
+projects, see :doc:`automation`.
 
 
 .. _how_it_works:
@@ -81,6 +81,9 @@ Installation:
     pip install scaraplate
 
 
+Scaraplate also requires ``git`` to be installed in the system
+(see :doc:`template`).
+
 To get started with scaraplate, you need to:
 
 1. Prepare a template (see :doc:`template` and specifically
@@ -109,6 +112,7 @@ of ... well, stuff, (the template) everywhere (the projects).
    template
    strategies
    gitremotes
+   automation
 
 
 Indices and tables

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -31,6 +31,8 @@ the following properties:
     in the inner ``{{cookiecutter.project_dest}}`` directory of the template repo.
 
 
+.. _no_input_mode:
+
 ``scaraplate rollup`` has a ``--no-input`` switch which doesn't ask for
 cookiecutter context values. This can be used to automate rollups
 when the cookiecutter context is already present in the target project

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,9 @@ check_untyped_defs = True
 [mypy-cookiecutter.*]
 ignore_missing_imports = True
 
+[mypy-gitlab.*]
+ignore_missing_imports = True
+
 [mypy-marshmallow.*]
 ignore_missing_imports = True
 
@@ -115,6 +118,8 @@ develop =
     pytest==5.2.1
     sphinx==2.2.0
     sphinx-rtd-theme==0.4.3
+gitlab =
+    python-gitlab>=1.6.0,<2
 
 [options.packages.find]
 where = src
@@ -135,6 +140,7 @@ python_package = scaraplate
 
 [tool:pytest]
 addopts =
+    -ra
     --junitxml=junit.xml
     --showlocals
     --verbose

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ install_requires =
     marshmallow>=2.15,<3
     packaging
     pyyaml>=3,<4
+    setuptools
 package_dir =
     = src
 packages = find:

--- a/src/scaraplate/__init__.py
+++ b/src/scaraplate/__init__.py
@@ -1,0 +1,21 @@
+from .automation import (
+    GitCloneProjectVCS,
+    GitCloneTemplateVCS,
+    ProjectVCS,
+    TemplateVCS,
+    automatic_rollup,
+)
+from .rollup import InvalidScaraplateTemplateError, rollup
+from .template import TemplateMeta
+
+
+__all__ = (
+    "GitCloneProjectVCS",
+    "GitCloneTemplateVCS",
+    "InvalidScaraplateTemplateError",
+    "ProjectVCS",
+    "TemplateMeta",
+    "TemplateVCS",
+    "automatic_rollup",
+    "rollup",
+)

--- a/src/scaraplate/automation/__init__.py
+++ b/src/scaraplate/automation/__init__.py
@@ -1,0 +1,11 @@
+from .base import ProjectVCS, TemplateVCS, automatic_rollup
+from .git import GitCloneProjectVCS, GitCloneTemplateVCS
+
+
+__all__ = (
+    "GitCloneProjectVCS",
+    "GitCloneTemplateVCS",
+    "ProjectVCS",
+    "TemplateVCS",
+    "automatic_rollup",
+)

--- a/src/scaraplate/automation/base.py
+++ b/src/scaraplate/automation/base.py
@@ -1,0 +1,76 @@
+import abc
+import logging
+from contextlib import ExitStack
+from pathlib import Path
+from typing import ContextManager, Mapping, Optional
+
+from scaraplate.rollup import rollup
+from scaraplate.template import TemplateMeta
+
+
+logger = logging.getLogger("scaraplate")
+
+__all__ = ("TemplateVCS", "ProjectVCS", "automatic_rollup")
+
+
+def automatic_rollup(
+    *,
+    template_vcs_ctx: ContextManager["TemplateVCS"],
+    project_vcs_ctx: ContextManager["ProjectVCS"],
+    extra_context: Optional[Mapping[str, str]] = None
+) -> None:
+    """XXX"""
+
+    with ExitStack() as stack:
+        # Clone target project and template
+        project_vcs = stack.enter_context(project_vcs_ctx)
+        template_vcs = stack.enter_context(template_vcs_ctx)
+
+        rollup(
+            template_dir=template_vcs.dest_path,
+            target_project_dir=project_vcs.dest_path,
+            no_input=True,
+            extra_context=extra_context,
+        )
+
+        if not project_vcs.is_dirty():
+            logger.info(
+                "scaraplate rollup didn't change anything -- the project "
+                "is in sync with template"
+            )
+            return
+
+        logger.info("scaraplate rollup produced some changes -- committing them...")
+        project_vcs.commit_changes(template_vcs.template_meta)
+        logger.info("scaraplate changes have been committed successfully")
+
+
+class TemplateVCS(abc.ABC):
+    """XXX"""
+
+    @property
+    @abc.abstractmethod
+    def dest_path(self) -> Path:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def template_meta(self) -> TemplateMeta:
+        pass
+
+
+class ProjectVCS(abc.ABC):
+    """XXX"""
+
+    @property
+    @abc.abstractmethod
+    def dest_path(self) -> Path:
+        pass
+
+    @abc.abstractmethod
+    def is_dirty(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def commit_changes(self, template_meta: TemplateMeta) -> None:
+        pass

--- a/src/scaraplate/automation/base.py
+++ b/src/scaraplate/automation/base.py
@@ -19,7 +19,23 @@ def automatic_rollup(
     project_vcs_ctx: ContextManager["ProjectVCS"],
     extra_context: Optional[Mapping[str, str]] = None
 ) -> None:
-    """XXX"""
+    """The main function of the automated rollup implementation.
+
+    This function accepts two context managers, which should return
+    two classes: :class:`.TemplateVCS` and :class:`.ProjectVCS`,
+    which represent the cloned template and target project
+    correspondingly.
+
+    The context managers should prepare the repos, e.g. they should
+    create a temporary directory, clone a repo there, and produce
+    a :class:`.TemplateVCS` or :class:`.ProjectVCS` class instance.
+
+    This function then applies scaraplate rollup of the template
+    to the target project in :ref:`no-input mode <no_input_mode>`.
+    If the target project contains any changes (as reported by
+    :meth:`.ProjectVCS.is_dirty`), they will be committed by calling
+    :meth:`.ProjectVCS.commit_changes`.
+    """
 
     with ExitStack() as stack:
         # Clone target project and template
@@ -46,31 +62,59 @@ def automatic_rollup(
 
 
 class TemplateVCS(abc.ABC):
-    """XXX"""
+    """A base class representing a template retrieved from a VCS
+    (probably residing in a temporary directory).
+
+    The resulting directory with template must be within a git repository,
+    see :doc:`template` for details. But it doesn't mean that it must
+    be retrieved from git. Template might be retrieved from anywhere,
+    it just has to be in git at the end. That git repo will be used
+    to fill the :class:`.TemplateMeta` structure.
+    """
 
     @property
     @abc.abstractmethod
     def dest_path(self) -> Path:
+        """Path to the root directory of the template."""
         pass
 
     @property
     @abc.abstractmethod
     def template_meta(self) -> TemplateMeta:
+        """:class:`.TemplateMeta` filled using the template's git repo."""
         pass
 
 
 class ProjectVCS(abc.ABC):
-    """XXX"""
+    """A base class representing a project retrieved from a VCS
+    (probably residing in a temporary directory).
+
+    The project might use any VCS, at this point there're no assumptions
+    made by scaraplate about the VCS.
+    """
 
     @property
     @abc.abstractmethod
     def dest_path(self) -> Path:
+        """Path to the root directory of the project."""
         pass
 
     @abc.abstractmethod
     def is_dirty(self) -> bool:
+        """Tell whether the project has any changes not committed
+        to the VCS."""
         pass
 
     @abc.abstractmethod
     def commit_changes(self, template_meta: TemplateMeta) -> None:
+        """Commit the changes made to the project. This method is
+        responsible for delivering the changes back to the place
+        the project was retrieved from. For example, if the project
+        is using ``git`` and it was cloned to a temporary directory,
+        then this method should commit the changes and push them back
+        to git remote.
+
+        This method will be called only if :meth:`.ProjectVCS.is_dirty`
+        has returned True.
+        """
         pass

--- a/src/scaraplate/automation/git.py
+++ b/src/scaraplate/automation/git.py
@@ -24,7 +24,14 @@ def scaraplate_version() -> str:
 
 
 class GitCloneTemplateVCS(TemplateVCS):
-    """XXX"""
+    """A ready to use :class:`.TemplateVCS` implementation which:
+
+    - Uses git
+    - Clones a git repo with the template to a temporary directory
+      (which is cleaned up afterwards)
+    - Allows to specify an inner dir inside the git repo as the template
+      root (which is useful for monorepos)
+    """
 
     def __init__(self, template_path: Path, template_meta: TemplateMeta) -> None:
         self._template_path = template_path
@@ -47,7 +54,18 @@ class GitCloneTemplateVCS(TemplateVCS):
         clone_ref: Optional[str] = None,
         monorepo_inner_path: Optional[Path] = None,
     ) -> Iterator["GitCloneTemplateVCS"]:
-        """XXX"""
+        """Provides an instance of this class by issuing ``git clone``
+        to a tempdir when entering the context manager. Returns a context
+        manager object which after ``__enter__`` returns an instance
+        of this class.
+
+        :param clone_url: Any valid ``git clone`` url.
+        :param clone_ref: Git ref to checkout after clone
+            (i.e. branch or tag name).
+        :param monorepo_inner_path: Path to the root dir of template
+            relative to the root of the repo. If ``None``, the root of
+            the repo will be used as the root of template.
+        """
 
         with tempfile.TemporaryDirectory() as tmpdir_name:
             tmpdir_path = Path(tmpdir_name).resolve()
@@ -77,7 +95,16 @@ class GitCloneTemplateVCS(TemplateVCS):
 
 
 class GitCloneProjectVCS(ProjectVCS):
-    """XXX"""
+    """A ready to use :class:`.ProjectVCS` implementation which:
+
+    - Uses git
+    - Clones a git repo with the project to a temporary directory
+      (which is cleaned up afterwards)
+    - Allows to specify an inner dir inside the git repo as the project
+      root (which is useful for monorepos)
+    - Implements :meth:`.ProjectVCS.commit_changes` as
+      ``git commit`` + ``git push``.
+    """
 
     def __init__(
         self,
@@ -177,7 +204,37 @@ class GitCloneProjectVCS(ProjectVCS):
             "* template ref: {template_meta.head_ref}\n"
         ),
     ) -> Iterator["GitCloneProjectVCS"]:
-        """XXX"""
+        """Provides an instance of this class by issuing ``git clone``
+        to a tempdir when entering the context manager. Returns a context
+        manager object which after ``__enter__`` returns an instance
+        of this class.
+
+        :param clone_url: Any valid ``git clone`` url.
+        :param clone_ref: Git ref to checkout after clone
+            (i.e. branch or tag name).
+        :param monorepo_inner_path: Path to the root dir of project
+            relative to the root of the repo. If ``None``, the root of
+            the repo will be used as the root of project.
+        :param changes_branch: The branch name where the changes should be
+            pushed in the remote. Might be the same as ``clone_ref``.
+            Note that this branch is never force-pushed. If upon push
+            the branch already exists in remote and its one-commit diff
+            is different from the one-commit diff of the just created
+            local branch, then the remote branch will be deleted and
+            the local branch will be pushed to replace the previous one.
+        :param commit_author: Author name to use for ``git commit``, e.g.
+            ``John Doe <john@example.org>``.
+        :param commit_message_template: :meth:`str.format` template
+            which is used to produce a commit message when committing
+            the changes. Available format variables are:
+
+            - ``update_time`` [:class:`datetime.datetime`] -- the time
+              of update
+            - ``scaraplate_version`` [:class:`str`] -- scaraplate package
+              version
+            - ``template_meta`` [:class:`.TemplateMeta`] -- template meta
+              returned by :meth:`.TemplateVCS.template_meta`
+        """
 
         with tempfile.TemporaryDirectory() as tmpdir_name:
             tmpdir_path = Path(tmpdir_name).resolve()

--- a/src/scaraplate/automation/git.py
+++ b/src/scaraplate/automation/git.py
@@ -1,0 +1,299 @@
+import contextlib
+import datetime
+import logging
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+from urllib.parse import urlparse, urlunparse
+
+from pkg_resources import get_distribution
+
+from scaraplate.automation.base import ProjectVCS, TemplateVCS
+from scaraplate.config import get_scaraplate_yaml_options
+from scaraplate.template import TemplateMeta, _call_git, get_template_meta_from_git
+
+
+__all__ = ("GitCloneProjectVCS", "GitCloneTemplateVCS")
+
+logger = logging.getLogger("scaraplate")
+
+
+def scaraplate_version() -> str:
+    return get_distribution("scaraplate").version
+
+
+class GitCloneTemplateVCS(TemplateVCS):
+    """XXX"""
+
+    def __init__(self, template_path: Path, template_meta: TemplateMeta) -> None:
+        self._template_path = template_path
+        self._template_meta = template_meta
+
+    @property
+    def dest_path(self) -> Path:
+        return self._template_path
+
+    @property
+    def template_meta(self) -> TemplateMeta:
+        return self._template_meta
+
+    @classmethod
+    @contextlib.contextmanager
+    def clone(
+        cls,
+        clone_url: str,
+        *,
+        clone_ref: Optional[str] = None,
+        monorepo_inner_path: Optional[Path] = None,
+    ) -> Iterator["GitCloneTemplateVCS"]:
+        """XXX"""
+
+        with tempfile.TemporaryDirectory() as tmpdir_name:
+            tmpdir_path = Path(tmpdir_name).resolve()
+            template_path = tmpdir_path / "scaraplate_template"
+
+            Git.clone(
+                clone_url,
+                target_path=template_path,
+                ref=clone_ref,
+                # We need to strip credentials from the clone_url,
+                # because otherwise urls generated for TemplateMeta
+                # would contain them, and we don't want that.
+                strip_credentials_from_remote=True,
+            )
+
+            if monorepo_inner_path is not None:
+                template_path = template_path / monorepo_inner_path
+
+            scaraplate_yaml_options = get_scaraplate_yaml_options(template_path)
+            template_meta = get_template_meta_from_git(
+                template_path, git_remote_type=scaraplate_yaml_options.git_remote_type
+            )
+            if clone_ref is not None:
+                assert clone_ref == template_meta.head_ref
+
+            yield cls(template_path, template_meta)
+
+
+class GitCloneProjectVCS(ProjectVCS):
+    """XXX"""
+
+    def __init__(
+        self,
+        project_path: Path,
+        git: "Git",
+        *,
+        changes_branch: str,
+        commit_author: str,
+        commit_message_template: str,
+    ) -> None:
+        self._project_path = project_path
+        self._git = git
+        self.changes_branch = changes_branch
+        self.commit_author = commit_author
+        self.commit_message_template = commit_message_template
+        self.update_time = datetime.datetime.now()
+
+    @property
+    def dest_path(self) -> Path:
+        return self._project_path
+
+    def is_dirty(self) -> bool:
+        return self._git.is_dirty()
+
+    def commit_changes(self, template_meta: TemplateMeta) -> None:
+        assert self.is_dirty()
+
+        remote_branch = self._git.remote_ref(self.changes_branch)
+
+        # Create a definitely not existing local branch:
+        local_branch = f"{self.changes_branch}{uuid.uuid4()}"
+        self._git.checkout_branch(local_branch)
+
+        self._git.commit_all(
+            self.format_commit_message(template_meta=template_meta),
+            author=self.commit_author,
+        )
+
+        if not self._git.is_existing_ref(remote_branch):
+            self._git.push(self.changes_branch)
+        else:
+            # A branch with updates already exists in the remote.
+
+            if self._git.is_same_commit(remote_branch, f"{local_branch}^1"):
+                # The `changes_branch` is the same as the clone branch,
+                # so essentially the created commit forms a linear history.
+                # No need for any diffs here, we just need to push that.
+                self._git.push(self.changes_branch)
+            else:
+                # The two branches have diverged, we need to compare them:
+                changes: bool = not self._git.are_one_commit_diffs_equal(
+                    local_branch, remote_branch
+                )
+
+                if changes:
+                    # We could've used force push here, but instead we delete
+                    # the branch first, because in GitLab it would also close
+                    # the existing MR (if any), and we want that instead of
+                    # silently updating the old MR.
+                    self._git.push_branch_delete(self.changes_branch)
+                    self._git.push(self.changes_branch)
+                else:
+                    logger.info(
+                        "scaraplate did update the project, but there's "
+                        "an already existing branch in remote which diff "
+                        "is equal to the just produced changes"
+                    )
+
+        # Now we should ensure that a Pull Request exists for
+        # the `self.changes_branch`, but this class is designed to be agnostic
+        # from concrete git remotes, so it should be done in a child class.
+
+    def format_commit_message(self, *, template_meta: TemplateMeta) -> str:
+        return self.commit_message_template.format(
+            # TODO retrieve path from self.clone_url and pass it here too?
+            # (but careful: that clone_url might contain credentials).
+            update_time=self.update_time,
+            scaraplate_version=scaraplate_version(),
+            template_meta=template_meta,
+        )
+
+    @classmethod
+    @contextlib.contextmanager
+    def clone(
+        cls,
+        clone_url: str,
+        *,
+        clone_ref: Optional[str] = None,
+        monorepo_inner_path: Optional[Path] = None,
+        changes_branch: str,
+        commit_author: str,
+        commit_message_template: str = (
+            "Scheduled template update ({update_time:%Y-%m-%d})\n"
+            "\n"
+            "* scaraplate version: {scaraplate_version}\n"
+            "* template commit: {template_meta.commit_url}\n"
+            "* template ref: {template_meta.head_ref}\n"
+        ),
+    ) -> Iterator["GitCloneProjectVCS"]:
+        """XXX"""
+
+        with tempfile.TemporaryDirectory() as tmpdir_name:
+            tmpdir_path = Path(tmpdir_name).resolve()
+            project_path = tmpdir_path / "scaraplate_project"
+
+            git = Git.clone(clone_url, target_path=project_path, ref=clone_ref)
+
+            if monorepo_inner_path is not None:
+                project_path = project_path / monorepo_inner_path
+
+            yield cls(
+                project_path,
+                git,
+                changes_branch=changes_branch,
+                commit_author=commit_author,
+                commit_message_template=commit_message_template,
+            )
+
+
+class Git:
+    def __init__(self, cwd: Path, remote: str = "origin") -> None:
+        self.cwd = cwd
+        self.remote = remote
+
+    def remote_ref(self, ref: str) -> str:
+        return f"{self.remote}/{ref}"
+
+    def checkout_branch(self, branch: str) -> None:
+        self._git(["checkout", "-b", branch])
+
+    def commit_all(self, commit_message: str, author: Optional[str] = None) -> None:
+        self._git(["add", "--all"])
+        extra: List[str] = []
+        if author is not None:
+            extra = ["--author", author]
+        self._git(
+            ["commit", "-m", commit_message, *extra],
+            env={
+                # git would fail if there's no `user.email` in the local
+                # git config, even if `--author` is specified.
+                "USERNAME": "scaraplate",
+                "EMAIL": "scaraplate@localhost",
+            },
+        )
+
+    def is_dirty(self) -> bool:
+        return bool(self._git(["status", "--porcelain"]))
+
+    def is_existing_ref(self, ref: str) -> bool:
+        try:
+            self._git(["rev-parse", "--verify", ref])
+        except RuntimeError:
+            return False
+        else:
+            return True
+
+    def is_same_commit(self, ref1: str, ref2: str) -> bool:
+        commit1 = self._git(["rev-parse", "--verify", ref1])
+        commit2 = self._git(["rev-parse", "--verify", ref2])
+        return commit1 == commit2
+
+    def are_one_commit_diffs_equal(self, ref1: str, ref2: str) -> bool:
+        diff1 = self._git(["diff", f"{ref1}^1..{ref1}"])
+        diff2 = self._git(["diff", f"{ref2}^1..{ref2}"])
+        return diff1 == diff2
+
+    def push_branch_delete(self, branch: str) -> None:
+        self._git(["push", "--delete", self.remote, branch])
+
+    def push(self, ref: str) -> None:
+        # https://stackoverflow.com/a/4183856
+        self._git(["push", self.remote, f"HEAD:{ref}"])
+
+    def _git(self, args: List[str], *, env: Optional[Dict[str, str]] = None) -> str:
+        return _call_git(args, cwd=self.cwd, env=env)
+
+    @classmethod
+    def clone(
+        cls,
+        clone_url: str,
+        *,
+        target_path: Path,
+        ref: str = None,
+        strip_credentials_from_remote: bool = False,
+    ) -> "Git":
+        remote = "origin"
+        clone_url_without_creds = strip_credentials_from_git_remote(clone_url)
+
+        args = ["clone", clone_url, target_path.name]
+
+        if ref is not None:
+            # git-clone(1) explicitly mentions that both branches and tags
+            # are allowed in the `--branch`.
+            args.extend(["--branch", ref])
+
+        _call_git(args, cwd=target_path.parent)
+
+        if not target_path.is_dir():
+            raise RuntimeError(
+                f"Expected `git` to clone '{clone_url_without_creds}' to "
+                f"'{target_path}', but it didn't"
+            )
+
+        if strip_credentials_from_remote:
+            _call_git(
+                ["remote", "set-url", remote, clone_url_without_creds], cwd=target_path
+            )
+
+        return cls(cwd=target_path, remote=remote)
+
+
+def strip_credentials_from_git_remote(remote: str) -> str:
+    parsed = urlparse(remote)
+    if not parsed.scheme:
+        # Not a URL (probably an SSH remote)
+        return remote
+    assert parsed.hostname is not None
+    clean = parsed._replace(netloc=parsed.hostname)
+    return urlunparse(clean)

--- a/src/scaraplate/automation/gitlab.py
+++ b/src/scaraplate/automation/gitlab.py
@@ -1,0 +1,210 @@
+import contextlib
+import logging
+from pathlib import Path
+from typing import Iterator, Optional
+from urllib.parse import urljoin, urlparse, urlunparse
+
+from scaraplate.automation.base import ProjectVCS, TemplateVCS
+from scaraplate.automation.git import (
+    GitCloneProjectVCS,
+    GitCloneTemplateVCS,
+    scaraplate_version,
+)
+from scaraplate.template import TemplateMeta
+
+
+try:
+    import gitlab
+except ImportError:
+    gitlab_available = False
+else:
+    gitlab_available = True
+
+
+logger = logging.getLogger("scaraplate")
+
+
+def ensure_gitlab_is_installed():
+    if not gitlab_available:
+        raise ImportError(
+            "python-gitlab must be installed in order to use gitlab integrations. "
+            'Install with `pip install "scaraplate[gitlab]"`.'
+        )
+
+
+def gitlab_clone_url(project_url: str, private_token: Optional[str]) -> str:
+    parsed = urlparse(project_url)
+    assert parsed.scheme
+
+    if private_token:
+        clean = parsed._replace(netloc=f"oauth2:{private_token}@{parsed.hostname}")
+    else:
+        clean = parsed
+    if not clean.path.endswith(".git"):
+        clean = clean._replace(path=f"{clean.path}.git")
+    return urlunparse(clean)
+
+
+def gitlab_project_url(gitlab_url: str, full_project_name: str) -> str:
+    return urljoin(gitlab_url, full_project_name)
+
+
+class GitLabCloneTemplateVCS(TemplateVCS):
+    """XXX"""
+
+    def __init__(self, git_clone: GitCloneTemplateVCS) -> None:
+        self._git_clone = git_clone
+
+    @property
+    def dest_path(self) -> Path:
+        return self._git_clone.dest_path
+
+    @property
+    def template_meta(self) -> TemplateMeta:
+        return self._git_clone.template_meta
+
+    @classmethod
+    @contextlib.contextmanager
+    def clone(
+        cls,
+        project_url: str,
+        private_token: Optional[str] = None,
+        *,
+        clone_ref: Optional[str] = None,
+        monorepo_inner_path: Optional[Path] = None,
+    ) -> Iterator["GitLabCloneTemplateVCS"]:
+        """XXX"""
+
+        with GitCloneTemplateVCS.clone(
+            clone_url=gitlab_clone_url(project_url, private_token),
+            clone_ref=clone_ref,
+            monorepo_inner_path=monorepo_inner_path,
+        ) as git_clone:
+            yield cls(git_clone)
+
+
+class GitLabMRProjectVCS(ProjectVCS):
+    """XXX"""
+
+    def __init__(
+        self,
+        git_clone: GitCloneProjectVCS,
+        *,
+        gitlab_project,
+        mr_title_template: str,
+        mr_description_markdown_template: str,
+    ) -> None:
+        self._git_clone = git_clone
+        self._gitlab_project = gitlab_project
+        self.mr_title_template = mr_title_template
+        self.mr_description_markdown_template = mr_description_markdown_template
+
+    @property
+    def dest_path(self) -> Path:
+        return self._git_clone.dest_path
+
+    def is_dirty(self) -> bool:
+        return self._git_clone.is_dirty()
+
+    def commit_changes(self, template_meta: TemplateMeta) -> None:
+        self._git_clone.commit_changes(template_meta)
+
+        if self._git_clone.changes_branch == self._gitlab_project.default_branch:
+            logger.info(
+                "Skipping MR creation step as `changes_branch` and `default_branch` "
+                "are the same, i.e. the changes are already in the target branch."
+            )
+        else:
+            self.create_merge_request(
+                title=self.format_merge_request_title(template_meta=template_meta),
+                description=self.format_merge_request_description(
+                    template_meta=template_meta
+                ),
+            )
+
+    def format_merge_request_title(self, *, template_meta: TemplateMeta) -> str:
+        return self.mr_title_template.format(
+            update_time=self._git_clone.update_time, template_meta=template_meta
+        )
+
+    def format_merge_request_description(self, *, template_meta: TemplateMeta) -> str:
+        # The returned string would be treated as markdown markup.
+        return self.mr_description_markdown_template.format(
+            update_time=self._git_clone.update_time,
+            scaraplate_version=scaraplate_version(),
+            template_meta=template_meta,
+        )
+
+    def create_merge_request(self, *, title: str, description: str) -> None:
+        existing_mr = self.get_merge_request()
+        if existing_mr is not None:
+            logger.info(f"Skipping MR creation as it already exists: {existing_mr!r}")
+            return
+
+        self._gitlab_project.mergerequests.create(
+            {
+                "description": description,
+                "should_remove_source_branch": True,
+                "source_branch": self._git_clone.changes_branch,
+                "target_branch": self._gitlab_project.default_branch,
+                "title": title,
+            }
+        )
+
+    def get_merge_request(self):
+        merge_requests = self._gitlab_project.mergerequests.list(
+            state="opened",
+            source_branch=self._git_clone.changes_branch,
+            target_branch=self._gitlab_project.default_branch,
+        )
+
+        if not merge_requests:
+            return None
+
+        assert len(merge_requests) == 1, merge_requests
+        merge_request = merge_requests[0]
+        return merge_request
+
+    @classmethod
+    @contextlib.contextmanager
+    def clone(
+        cls,
+        gitlab_url: str,
+        full_project_name: str,
+        private_token: str,
+        *,
+        mr_title_template: str = "Scheduled template update ({update_time:%Y-%m-%d})",
+        mr_description_markdown_template: str = (
+            "* scaraplate version: `{scaraplate_version}`\n"
+            "* template commit: {template_meta.commit_url}\n"
+            "* template ref: {template_meta.head_ref}\n"
+        ),
+        commit_author: Optional[str] = None,
+        **kwargs,
+    ) -> Iterator["GitLabMRProjectVCS"]:
+        """XXX"""
+
+        ensure_gitlab_is_installed()
+        client = gitlab.Gitlab(url=gitlab_url, private_token=private_token, timeout=30)
+        client.auth()
+
+        gitlab_project = client.projects.get(full_project_name)
+        project_url = gitlab_project_url(gitlab_url, full_project_name)
+        user = client.user
+        commit_author = commit_author or f"{user.name} <{user.email}>"
+
+        # pylint wants mandatory arguments to be passed explicitly:
+        changes_branch = kwargs.pop("changes_branch")
+
+        with GitCloneProjectVCS.clone(
+            clone_url=gitlab_clone_url(project_url, private_token),
+            changes_branch=changes_branch,
+            commit_author=commit_author,
+            **kwargs,
+        ) as git_clone:
+            yield cls(
+                git_clone,
+                gitlab_project=gitlab_project,
+                mr_title_template=mr_title_template,
+                mr_description_markdown_template=mr_description_markdown_template,
+            )

--- a/src/scaraplate/template.py
+++ b/src/scaraplate/template.py
@@ -12,6 +12,7 @@ class TemplateMeta(NamedTuple):
     commit_hash: str
     commit_url: str
     is_git_dirty: bool
+    head_ref: Optional[str]
 
 
 def get_template_meta_from_git(
@@ -27,6 +28,7 @@ def get_template_meta_from_git(
         commit_hash=commit_hash,
         commit_url=git_remote.commit_url(commit_hash),
         is_git_dirty=_is_git_dirty(template_path),
+        head_ref=_git_resolve_head(template_path),
     )
 
 
@@ -36,6 +38,14 @@ def _git_head_commit_hash(cwd: Path) -> str:
 
 def _is_git_dirty(cwd: Path) -> bool:
     return bool(_call_git(["git", "status", "--porcelain"], cwd))
+
+
+def _git_resolve_head(cwd: Path) -> Optional[str]:
+    ref = _call_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    if ref == "HEAD":
+        # Detached HEAD (some specific commit has been checked out).
+        return None
+    return ref
 
 
 def _git_remote_origin(cwd: Path) -> str:

--- a/src/scaraplate/template.py
+++ b/src/scaraplate/template.py
@@ -1,6 +1,7 @@
+import os
 import subprocess
 from pathlib import Path
-from typing import NamedTuple, Optional, Sequence, Type
+from typing import Dict, NamedTuple, Optional, Sequence, Type
 
 from scaraplate.gitremotes import GitRemote, make_git_remote
 
@@ -33,15 +34,15 @@ def get_template_meta_from_git(
 
 
 def _git_head_commit_hash(cwd: Path) -> str:
-    return _call_git(["git", "rev-parse", "--verify", "HEAD"], cwd)
+    return _call_git(["rev-parse", "--verify", "HEAD"], cwd)
 
 
 def _is_git_dirty(cwd: Path) -> bool:
-    return bool(_call_git(["git", "status", "--porcelain"], cwd))
+    return bool(_call_git(["status", "--porcelain"], cwd))
 
 
 def _git_resolve_head(cwd: Path) -> Optional[str]:
-    ref = _call_git(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    ref = _call_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
     if ref == "HEAD":
         # Detached HEAD (some specific commit has been checked out).
         return None
@@ -50,17 +51,35 @@ def _git_resolve_head(cwd: Path) -> Optional[str]:
 
 def _git_remote_origin(cwd: Path) -> str:
     # Would raise if there's no remote called `origin`.
-    return _call_git(["git", "config", "--get", "remote.origin.url"], cwd)
+    return _call_git(["config", "--get", "remote.origin.url"], cwd)
 
 
-def _call_git(command: Sequence[str], cwd: Path) -> str:
+def _call_git(
+    command: Sequence[str], cwd: Path, *, env: Optional[Dict[str, str]] = None
+) -> str:
+    env_combined = dict(os.environ)
+    if env:
+        env_combined.update(env)
+
     try:
-        out = subprocess.run(command, cwd=cwd, stdout=subprocess.PIPE, check=True)
-    except Exception:
+        out = subprocess.run(
+            ["git", *command],
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            env=env_combined,
+        )
+    except subprocess.CalledProcessError as e:
         raise RuntimeError(
-            f"{command} command failed in the template "
+            f"{command} command failed in the directory "
             f"'{cwd}'. "
             f"Ensure that it is a valid git repo."
+            f"\n"
+            f"stdout:\n"
+            f"{e.stdout.decode()}\n"
+            f"stderr:\n"
+            f"{e.stderr.decode()}\n"
         )
     else:
         return out.stdout.decode().strip()

--- a/tests/automation/conftest.py
+++ b/tests/automation/conftest.py
@@ -1,4 +1,9 @@
+import http.server
+import socketserver
+import threading
+from concurrent.futures import Future
 from pathlib import Path
+from typing import Any, Callable, List, Optional
 
 import pytest
 
@@ -56,3 +61,122 @@ def project_bare_git_repo(tempdir_path, init_git_and_commit, call_git):
     convert_git_repo_to_bare(call_git, cwd=target_project_path)
 
     return target_project_path
+
+
+@pytest.fixture
+def http_server():
+    server_thread = HttpServerThread()
+    server_thread.start()
+    yield server_thread
+    server_thread.stop()
+    server_thread.join()
+
+
+class HttpServerThread(threading.Thread):
+    spinup_timeout = 10
+
+    def __init__(self):
+        self.server_host = "127.0.0.1"
+        self.server_port = None  # randomly selected by OS
+
+        self.http_server = None
+        self._errors: List[Exception] = []
+        self.request_handler: Optional[Callable[..., Any]] = None
+
+        # Future is generic. Pylint is wrong.
+        # https://github.com/python/typeshed/blob/6e4708ebf3a482aa8d524196712c37c9fd645953/stdlib/3/concurrent/futures/_base.pyi#L26  # noqa
+        self.socket_created_future: Future[  # pylint: disable=unsubscriptable-object
+            bool
+        ] = Future()
+
+        super().__init__()
+        self.daemon = True
+
+    def set_request_handler(
+        self, request_handler: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        assert self.request_handler is None
+        self.request_handler = request_handler
+        return request_handler
+
+    def get_url(self):
+        assert self.socket_created_future.result(self.spinup_timeout)
+        return f"http://{self.server_host}:{self.server_port}"
+
+    def run(self):
+        assert (
+            self.http_server is None
+        ), "This class is not reentrable. Please create a new instance."
+
+        thread = self
+
+        class Server(http.server.BaseHTTPRequestHandler):
+            def __request_handler(self, method):
+                if thread.request_handler is None:  # pragma: no cover
+                    self.send_error(500, "request_handler is None")
+                else:
+                    try:
+                        # https://stackoverflow.com/a/20879937
+                        body = self.rfile.read(
+                            int(self.headers.get("content-length", 0))
+                        )
+                        # fmt: off
+                        code, headers, body = (
+                            thread.request_handler(  # pylint: disable=not-callable
+                                method, self.path, headers=self.headers, body=body
+                            )
+                        )
+                        # fmt: on
+                        self.send_response(code)
+                        for name, value in headers.items():
+                            self.send_header(name, value)
+                        self.end_headers()
+                        self.wfile.write(body)
+                    except Exception as e:  # pragma: no cover
+                        thread._errors.append(e)
+
+            def do_HEAD(self):  # pragma: no cover
+                self.__request_handler("HEAD")
+
+            def do_GET(self):
+                self.__request_handler("GET")
+
+            def do_POST(self):  # pragma: no cover
+                self.__request_handler("POST")
+
+            def do_PATCH(self):  # pragma: no cover
+                self.__request_handler("PATCH")
+
+        # ThreadingTCPServer offloads connections to separate threads, so
+        # the serve_forever loop doesn't block until connection is closed
+        # (unlike TCPServer). This allows to shutdown the serve_forever loop
+        # even if there's an open connection.
+        try:
+            # TODO: switch to http.server.ThreadingHTTPServer
+            # when the py36 support would be dropped
+            self.http_server = socketserver.ThreadingTCPServer(
+                (self.server_host, 0), Server
+            )
+
+            # don't hang if there're some open connections
+            self.http_server.daemon_threads = True  # type: ignore
+
+            self.server_port = self.http_server.server_address[1]
+        except Exception as e:  # pragma: no cover
+            self.socket_created_future.set_exception(e)
+            raise
+        else:
+            self.socket_created_future.set_result(True)
+
+        self.http_server.serve_forever()
+
+    def stop(self):
+        assert self.http_server is not None
+        self.http_server.shutdown()  # stop serve_forever()
+        self.http_server.server_close()
+
+        # assert not self._errors
+        # ^^^ gives unreadable assertions in pytest
+        # This is better:
+        if self._errors:
+            raise self._errors[0]

--- a/tests/automation/conftest.py
+++ b/tests/automation/conftest.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+
+def convert_git_repo_to_bare(call_git, *, cwd: Path) -> None:
+    """Git bare repo is a git repo without a working copy. `git clone`
+    can clone these repos my simply pointing at their location in the local
+    filesystem.
+    """
+    # https://stackoverflow.com/a/3251126
+    call_git("git config --bool core.bare true", cwd=cwd)
+
+
+@pytest.fixture
+def template_bare_git_repo(tempdir_path, init_git_and_commit, call_git):
+    template_path = tempdir_path / "remote_template"
+
+    cookiecutter_path = template_path / "{{cookiecutter.project_dest}}"
+    cookiecutter_path.mkdir(parents=True)
+    (cookiecutter_path / "sense_vars").write_text("{{ cookiecutter|jsonify }}\n")
+    (cookiecutter_path / ".scaraplate.conf").write_text(
+        """[cookiecutter_context]
+{%- for key, value in cookiecutter.items()|sort %}
+{{ key }} = {{ value }}
+{%- endfor %}
+"""
+    )
+    (template_path / "cookiecutter.json").write_text(
+        '{"project_dest": "test", "key1": null, "key2": null}'
+    )
+    (template_path / "scaraplate.yaml").write_text(
+        """
+git_remote_type: scaraplate.gitremotes.GitLab
+default_strategy: scaraplate.strategies.Overwrite
+strategies_mapping: {}
+        """
+    )
+    init_git_and_commit(template_path, with_remote=False)
+    call_git("git branch master2", cwd=template_path)
+
+    convert_git_repo_to_bare(call_git, cwd=template_path)
+
+    return template_path
+
+
+@pytest.fixture
+def project_bare_git_repo(tempdir_path, init_git_and_commit, call_git):
+    target_project_path = tempdir_path / "remote_project"
+
+    target_project_path.mkdir(parents=True)
+    (target_project_path / "readme").write_text("hi")
+    init_git_and_commit(target_project_path, with_remote=False)
+    call_git("git branch master2", cwd=target_project_path)
+
+    convert_git_repo_to_bare(call_git, cwd=target_project_path)
+
+    return target_project_path

--- a/tests/automation/test_git.py
+++ b/tests/automation/test_git.py
@@ -1,0 +1,197 @@
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from scaraplate.automation.base import automatic_rollup
+from scaraplate.automation.git import (
+    GitCloneProjectVCS,
+    GitCloneTemplateVCS,
+    strip_credentials_from_git_remote,
+)
+
+
+@contextlib.contextmanager
+def git_unbare_repo(git_path: Path, call_git):
+    call_git("git config --bool core.bare false", cwd=git_path)
+    try:
+        yield
+    finally:
+        call_git("git config --bool core.bare true", cwd=git_path)
+
+
+def convert_bare_to_monorepo(dest: str, git_path: Path, call_git):
+    with git_unbare_repo(git_path, call_git):
+        dest_path = git_path / dest
+        dest_path.mkdir()
+
+        for child in git_path.iterdir():
+            if child.name in (".git", dest):
+                continue
+            child.rename(dest_path / child.name)
+
+        call_git("git add --all .", cwd=git_path)
+        call_git('git commit -m "convert to monorepo"', cwd=git_path)
+        call_git("git branch -f master2 master", cwd=git_path)
+
+
+@pytest.mark.parametrize(
+    "target_branch, clone_ref",
+    [
+        ("updates", None),
+        ("updates", "master2"),
+        ("updates", "master"),
+        ("master", None),
+        # master-master2 is excluded, because cloning a non-default branch and
+        # committing the changes back to default is ridiculous
+        ("master", "master"),
+    ],
+)
+@pytest.mark.parametrize("monorepo_inner_path", ["inner", None])
+def test_automatic_rollup(
+    template_bare_git_repo: Path,
+    project_bare_git_repo: Path,
+    target_branch,
+    clone_ref,
+    monorepo_inner_path,
+    call_git,
+):
+    if monorepo_inner_path is not None:
+        convert_bare_to_monorepo(monorepo_inner_path, template_bare_git_repo, call_git)
+        convert_bare_to_monorepo(monorepo_inner_path, project_bare_git_repo, call_git)
+
+    assert "master" == call_git(
+        "git rev-parse --abbrev-ref HEAD", cwd=project_bare_git_repo
+    )
+    master_commit_hash = call_git(
+        "git rev-parse --verify master", cwd=project_bare_git_repo
+    )
+    template_commit_hash = call_git(
+        f"git rev-parse --verify {clone_ref or 'master'}", cwd=template_bare_git_repo
+    )
+
+    automatic_rollup(
+        template_vcs_ctx=GitCloneTemplateVCS.clone(
+            clone_url=str(template_bare_git_repo),  # a clonable remote URL
+            clone_ref=clone_ref,
+            monorepo_inner_path=monorepo_inner_path,
+        ),
+        project_vcs_ctx=GitCloneProjectVCS.clone(
+            clone_url=str(project_bare_git_repo),  # a clonable remote URL
+            clone_ref=clone_ref,
+            monorepo_inner_path=monorepo_inner_path,
+            changes_branch=target_branch,
+            commit_author="pytest <tests@none>",
+        ),
+        extra_context={"key1": "value1", "key2": "value2"},
+    )
+
+    target_branch_commit_hash = call_git(
+        f"git rev-parse --verify {target_branch}", cwd=project_bare_git_repo
+    )
+    if target_branch == "master":
+        # Ensure that master branch has advanced
+        assert master_commit_hash != target_branch_commit_hash
+
+    commit_message = call_git(
+        f'git log --pretty=format:"%B" -n 1 {target_branch}', cwd=project_bare_git_repo
+    )
+    assert (clone_ref or "master") in commit_message  # template clone ref
+    assert template_commit_hash in commit_message
+
+    # Apply again (this time we expect no changes)
+    automatic_rollup(
+        template_vcs_ctx=GitCloneTemplateVCS.clone(
+            clone_url=str(template_bare_git_repo),  # a clonable remote URL
+            clone_ref=clone_ref,
+            monorepo_inner_path=monorepo_inner_path,
+        ),
+        project_vcs_ctx=GitCloneProjectVCS.clone(
+            clone_url=str(project_bare_git_repo),  # a clonable remote URL
+            clone_ref=clone_ref,
+            monorepo_inner_path=monorepo_inner_path,
+            changes_branch=target_branch,
+            commit_author="pytest <tests@none>",
+        ),
+        extra_context={"key1": "value1", "key2": "value2"},
+    )
+
+    target_branch_commit_hash_2 = call_git(
+        f"git rev-parse --verify {target_branch}", cwd=project_bare_git_repo
+    )
+    assert target_branch_commit_hash == target_branch_commit_hash_2
+
+
+def test_automatic_rollup_with_existing_target_branch(
+    template_bare_git_repo: Path, project_bare_git_repo: Path, call_git
+):
+    target_branch = "update"
+
+    assert "master" == call_git(
+        "git rev-parse --abbrev-ref HEAD", cwd=project_bare_git_repo
+    )
+    master_commit_hash = call_git(
+        "git rev-parse --verify master", cwd=project_bare_git_repo
+    )
+
+    # Create `update` branch with one version
+    automatic_rollup(
+        template_vcs_ctx=GitCloneTemplateVCS.clone(
+            clone_url=str(template_bare_git_repo)  # a clonable remote URL
+        ),
+        project_vcs_ctx=GitCloneProjectVCS.clone(
+            clone_url=str(project_bare_git_repo),  # a clonable remote URL
+            changes_branch=target_branch,
+            commit_author="pytest <tests@none>",
+        ),
+        extra_context={"key1": "first1", "key2": "first2"},
+    )
+
+    target_branch_commit_hash = call_git(
+        f"git rev-parse --verify {target_branch}", cwd=project_bare_git_repo
+    )
+
+    # Apply again (but another version of template -- note the changed
+    # extra_context
+    automatic_rollup(
+        template_vcs_ctx=GitCloneTemplateVCS.clone(
+            clone_url=str(template_bare_git_repo)  # a clonable remote URL
+        ),
+        project_vcs_ctx=GitCloneProjectVCS.clone(
+            clone_url=str(project_bare_git_repo),  # a clonable remote URL
+            changes_branch=target_branch,
+            commit_author="pytest <tests@none>",
+        ),
+        extra_context={"key1": "second1", "key2": "second2"},
+    )
+
+    master_commit_hash_2 = call_git(
+        "git rev-parse --verify master", cwd=project_bare_git_repo
+    )
+    target_branch_commit_hash_2 = call_git(
+        f"git rev-parse --verify {target_branch}", cwd=project_bare_git_repo
+    )
+    # The first push should be replaced with the second one:
+    assert target_branch_commit_hash != target_branch_commit_hash_2
+    # master should not be changed:
+    assert master_commit_hash == master_commit_hash_2
+
+
+@pytest.mark.parametrize(
+    "remote_url, expected_url",
+    [
+        (
+            "https://oauth2:xxxtokenxxx@mygitlab.com/myorg/myproj.git",
+            "https://mygitlab.com/myorg/myproj.git",
+        ),
+        (
+            "https://mygitlab.com/myorg/myproj.git",
+            "https://mygitlab.com/myorg/myproj.git",
+        ),
+        # I suppose ssh urls cannot contain a password?
+        ("git@mygitlab.com:myorg/myproj.git", "git@mygitlab.com:myorg/myproj.git"),
+        ("/var/myrepos/mybare", "/var/myrepos/mybare"),
+    ],
+)
+def test_strip_credentials_from_git_remote(remote_url, expected_url):
+    assert expected_url == strip_credentials_from_git_remote(remote_url)

--- a/tests/automation/test_git_wrapper.py
+++ b/tests/automation/test_git_wrapper.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+from scaraplate.automation.git import Git
+
+
+@pytest.fixture
+def git_repo(init_git_and_commit, tempdir_path):
+    repo_path = tempdir_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "readme").write_text("hi")
+    init_git_and_commit(repo_path, with_remote=False)
+
+    return repo_path
+
+
+@pytest.mark.parametrize(
+    "remote, ref, expected_ref", [("origin", "my-branch", "origin/my-branch")]
+)
+def test_git_remote_ref(remote, ref, expected_ref):
+    git = Git(cwd=Path("."), remote=remote)
+    assert expected_ref == git.remote_ref(ref)
+
+
+def test_git_commit(git_repo, call_git):
+    git = Git(git_repo)
+    assert not git.is_dirty()
+
+    (git_repo / "myfile").write_text("my precious")
+    assert git.is_dirty()
+
+    message = "my\nmultiline\nmessage"
+    author = "John Doe <whitehouse@gov>"
+    git.commit_all(message, author=author)
+    assert not git.is_dirty()
+
+    assert message == call_git("git log -1 --pretty=%B", cwd=git_repo)
+    assert author == call_git("git log -1 --pretty='%an <%ae>'", cwd=git_repo)
+
+
+def test_git_is_existing_ref(git_repo):
+    git = Git(git_repo)
+    assert git.is_existing_ref("master")
+    assert not git.is_existing_ref("origin/master")
+
+
+def test_git_are_one_commit_diffs_equal(git_repo, call_git):
+    git = Git(git_repo)
+
+    with pytest.raises(RuntimeError):
+        # These refs don't exist yet
+        git.are_one_commit_diffs_equal("t1", "t2")
+
+    # Create branch t1
+    git.checkout_branch("t1")
+    (git_repo / "common").write_text("same")
+    git.commit_all("m1")
+
+    # Move master 1 commit ahead
+    call_git("git checkout master", cwd=git_repo)
+    (git_repo / "some_file").write_text("i'ma sta")
+    call_git("git add .", cwd=git_repo)
+    call_git("git commit -m next", cwd=git_repo)
+
+    # Create branch t2
+    git.checkout_branch("t2")
+    (git_repo / "common").write_text("same")
+    git.commit_all("m2")
+
+    #      /-()  << t1 (/common == "same")
+    #     /
+    # -> () -> () -> ()  << t2 (/common == "same")
+    #           \
+    #            \  << master (/some_file == "i'ma sta")
+    assert git.are_one_commit_diffs_equal("t1", "t2")
+    assert git.are_one_commit_diffs_equal("master", "master")
+    assert not git.are_one_commit_diffs_equal("master", "t2")

--- a/tests/automation/test_gitlab.py
+++ b/tests/automation/test_gitlab.py
@@ -1,0 +1,224 @@
+import json
+from unittest.mock import call, patch, sentinel
+
+import pytest
+
+import scaraplate.automation.gitlab
+from scaraplate.automation.gitlab import (
+    GitLabCloneTemplateVCS,
+    GitLabMRProjectVCS,
+    gitlab_available,
+    gitlab_clone_url,
+    gitlab_project_url,
+)
+from scaraplate.template import TemplateMeta
+
+
+@pytest.mark.parametrize(
+    "project_url, private_token, expected_url",
+    [
+        (
+            "https://mygitlab.com/myorg/myproj.git",
+            "xxxtokenxxx",
+            "https://oauth2:xxxtokenxxx@mygitlab.com/myorg/myproj.git",
+        ),
+        (
+            "https://mygitlab.com/myorg/myproj",
+            "xxxtokenxxx",
+            "https://oauth2:xxxtokenxxx@mygitlab.com/myorg/myproj.git",
+        ),
+        (
+            "https://mygitlab.com/myorg/myproj",
+            None,
+            "https://mygitlab.com/myorg/myproj.git",
+        ),
+    ],
+)
+def test_gitlab_clone_url(project_url, private_token, expected_url):
+    assert expected_url == gitlab_clone_url(project_url, private_token)
+
+
+@pytest.mark.parametrize(
+    "gitlab_url, full_project_name, expected_url",
+    [
+        ("https://mygitlab.com", "myorg/myproj", "https://mygitlab.com/myorg/myproj"),
+        (
+            "https://mygitlab.com/",
+            "myorg/myproj.git",
+            "https://mygitlab.com/myorg/myproj.git",
+        ),
+    ],
+)
+def test_gitlab_project_url(gitlab_url, full_project_name, expected_url):
+    assert expected_url == gitlab_project_url(gitlab_url, full_project_name)
+
+
+def test_gitlab_clone_template(template_bare_git_repo, call_git):
+    with patch.object(
+        scaraplate.automation.gitlab,
+        "gitlab_clone_url",
+        return_value=str(template_bare_git_repo),
+    ) as mock_gitlab_clone_url:
+        with GitLabCloneTemplateVCS.clone(
+            project_url=sentinel.project_url, private_token=sentinel.private_token
+        ) as template_vcs:
+            # Ensure this is a valid git repo:
+            call_git("git status", cwd=template_vcs.dest_path)
+
+            assert template_vcs.template_meta.head_ref == "master"
+        assert mock_gitlab_clone_url.call_count == 1
+        assert mock_gitlab_clone_url.call_args == call(
+            sentinel.project_url, sentinel.private_token
+        )
+
+
+@pytest.mark.skipif(
+    gitlab_available, reason="gitlab should not be installed for this test"
+)
+def test_gitlab_mr_project_raises_without_gitlab():
+    with pytest.raises(ImportError):
+        with GitLabMRProjectVCS.clone(
+            gitlab_url="http://a",
+            full_project_name="a/aa",
+            private_token="zzz",
+            changes_branch="update",
+        ):
+            raise AssertionError("should not be executed")
+
+
+@pytest.mark.skipif(
+    not gitlab_available, reason="gitlab should be installed for this test"
+)
+@pytest.mark.parametrize(
+    "mr_exists, changes_branch",
+    [
+        (False, "update"),
+        (True, "update"),
+        (None, "master"),  # MRs cannot be created from default branch
+    ],
+)
+def test_gitlab_mr_project(
+    project_bare_git_repo, call_git, http_server, mr_exists, changes_branch
+):
+    requests = iter(
+        [
+            (
+                "GET",
+                "/api/v4/user",
+                {
+                    # https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users
+                    "name": "test user",
+                    "email": "test@notemail",
+                },
+                None,
+            ),
+            (
+                "GET",
+                "/api/v4/projects/a%2Faa",
+                {
+                    # https://docs.gitlab.com/ee/api/projects.html#get-single-project
+                    "id": 42,
+                    "name": "test project",
+                    "default_branch": "master",
+                },
+                None,
+            ),
+        ]
+        + (
+            []
+            if mr_exists is None
+            else [
+                (
+                    "GET",
+                    "/api/v4/projects/42/merge_requests"
+                    "?state=opened&source_branch=update&target_branch=master",
+                    [] if not mr_exists else [{"id": 98, "iid": 98}],
+                    None,
+                )
+            ]
+        )
+        + (
+            []
+            if mr_exists or mr_exists is None
+            else [
+                (
+                    "POST",  # type: ignore
+                    "/api/v4/projects/42/merge_requests",
+                    {"id": 99, "iid": 99},
+                    lambda body: mr_body_checker(body),
+                )
+            ]
+        )
+    )
+
+    def mr_body_checker(body):
+        data = json.loads(body.decode())
+        assert "1111111111111111111111111111111111111111" in data["description"]
+
+    @http_server.set_request_handler
+    def request_handler(method, path, headers, body):
+        assert headers["PRIVATE-TOKEN"] == "zzz"
+        try:
+            exp_method, exp_path, response, body_checker = next(requests)
+        except StopIteration:  # pragma: no cover
+            raise AssertionError(f"Received unexpected request {method} {path}")
+        assert method == exp_method
+        assert path == exp_path
+        if body_checker is not None:
+            body_checker(body)
+        return 200, {"Content-type": "application/json"}, json.dumps(response).encode()
+
+    with patch.object(
+        scaraplate.automation.gitlab,
+        "gitlab_clone_url",
+        return_value=str(project_bare_git_repo),
+    ) as mock_gitlab_clone_url:
+        with GitLabMRProjectVCS.clone(
+            gitlab_url=http_server.get_url(),
+            full_project_name="a/aa",
+            private_token="zzz",
+            changes_branch=changes_branch,
+        ) as project_vcs:
+            # Ensure this is a valid git repo:
+            call_git("git status", cwd=project_vcs.dest_path)
+
+            assert not project_vcs.is_dirty()
+
+            (project_vcs.dest_path / "hi").write_text("change!")
+            project_vcs.commit_changes(
+                TemplateMeta(
+                    git_project_url="https://testdomain/t/tt",
+                    commit_hash="1111111111111111111111111111111111111111",
+                    commit_url=(
+                        "https://testdomain/t/tt"
+                        "/commit/1111111111111111111111111111111111111111"
+                    ),
+                    is_git_dirty=False,
+                    head_ref="master",
+                )
+            )
+
+            commit_message = call_git(
+                f'git log --pretty=format:"%B" -n 1 {changes_branch}',
+                cwd=project_bare_git_repo,
+            )
+            assert "1111111111111111111111111111111111111111" in commit_message
+            assert "Scheduled" in commit_message
+
+            commit_author = call_git(
+                f'git log --pretty=format:"%aN <%aE>" -n 1 {changes_branch}',
+                cwd=project_bare_git_repo,
+            )
+            assert commit_author == "test user <test@notemail>"
+
+            assert "change!" == call_git(
+                f"git show {changes_branch}:hi", cwd=project_bare_git_repo
+            )
+
+        assert mock_gitlab_clone_url.call_count == 1
+        assert mock_gitlab_clone_url.call_args == call(
+            f"{http_server.get_url()}/a/aa", "zzz"
+        )
+
+        # ensure that all expected queries have been executed:
+        assert next(requests, ...) is ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,23 @@ def init_git_and_commit(call_git):
 
 @pytest.fixture
 def call_git():
-    def _call_git(shell_cmd: str, cwd: Path) -> None:
+    def _call_git(shell_cmd: str, cwd: Path) -> str:
         env = {
             "USERNAME": "tests_scaraplate",
             "EMAIL": "pytest@scaraplate",
             "PATH": os.getenv("PATH", os.defpath),
         }
-        subprocess.run(shell_cmd, shell=True, check=True, cwd=cwd, env=env, timeout=5)
+        out = subprocess.run(
+            shell_cmd,
+            shell=True,
+            check=True,
+            cwd=cwd,
+            env=env,
+            timeout=5,
+            stdout=subprocess.PIPE,
+        )
+        stdout = out.stdout.decode().strip()
+        print(stdout)
+        return stdout
 
     return _call_git

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -86,6 +86,7 @@ def run_strategy_test(
                     "/commit/1111111111111111111111111111111111111111"
                 ),
                 is_git_dirty=is_git_dirty,
+                head_ref="master",
             ),
             config=config,
         )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,11 @@
 import pytest
 
-from scaraplate.template import _git_head_commit_hash, _git_remote_origin, _is_git_dirty
+from scaraplate.template import (
+    _git_head_commit_hash,
+    _git_remote_origin,
+    _git_resolve_head,
+    _is_git_dirty,
+)
 
 
 def test_git_head_commit_hash_valid(init_git_and_commit, tempdir_path):
@@ -16,6 +21,34 @@ def test_git_head_commit_hash_invalid(tempdir_path):
     # tempdir_path is not under a git repo.
     with pytest.raises(RuntimeError):
         _git_head_commit_hash(tempdir_path)
+
+
+def test_git_head_ref_valid(init_git_and_commit, tempdir_path):
+    repo_path = tempdir_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "myfile").write_text("hi")
+    init_git_and_commit(repo_path)
+
+    assert "master" == _git_resolve_head(repo_path)
+
+
+def test_git_head_ref_valid_detached(init_git_and_commit, call_git, tempdir_path):
+    repo_path = tempdir_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "myfile").write_text("hi")
+    init_git_and_commit(repo_path)
+
+    # Detach the HEAD
+    commit_hash = _git_head_commit_hash(repo_path)
+    call_git(f"git checkout {commit_hash}", cwd=repo_path)
+
+    assert _git_resolve_head(repo_path) is None
+
+
+def test_git_head_ref_invalid(tempdir_path):
+    # tempdir_path is not under a git repo.
+    with pytest.raises(RuntimeError):
+        _git_resolve_head(tempdir_path)
 
 
 def test_git_is_dirty(init_git_and_commit, tempdir_path, call_git):

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,31 @@
 [tox]
 envlist=
-    py{36,37,38,39},
+    py{36,37,38,39}{-minimal,-full},
     lint,
     check-docs,
 
 [testenv]
+; Skip coverage for -minimal, because it would fail due to low coverage
+; since not everything is tested when some extras are not installed.
+commands = sh -c 'envname={envname}; if [ "$envname" != "$\{envname%-minimal\}" ]; then pytest; else make test; fi'
 extras =
     develop
-commands = make test
+    full: gitlab
 usedevelop = True
-whitelist_externals = make
+whitelist_externals =
+    make
+    sh
 
 [testenv:lint]
 basepython = python3
 commands = make lint
+extras =
+    develop
+    gitlab
 
 [testenv:check-docs]
 basepython = python3
 commands = make check-docs
+extras =
+    develop
+    gitlab


### PR DESCRIPTION
This PR adds a new `scaraplate.automation` package, which would contain utilities for simplifying automation of scaraplate rollup (see #1). At this time there're no plans for CLI, so all configuration should be done in Python. However, it should be quite simple. There're some examples in the tests.

This is a WIP PR, because:
- ~~Docs need to be added~~ upd: done
- ~~I haven't read it well yet, perhaps it needs some polishing~~ upd: done

This will land in scaraplate 0.2, along with support for GitLab. Other remotes (such as GitHub) are not planned for this PR/release.

Closes #1