### PR TITLE
Add jinja2 support to strategies mapping

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ include_package_data = True
 install_requires =
     click>=6,<8
     cookiecutter>=1.6,<2
+    jinja2>=2.7,<3
     marshmallow>=2.15,<3
     packaging
     pyyaml>=3,<4

--- a/src/scaraplate/cookiecutter.py
+++ b/src/scaraplate/cookiecutter.py
@@ -15,7 +15,10 @@ might be specified in ``scaraplate.yaml`` like this:
 import abc
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Dict
+from typing import Dict, NewType
+
+
+CookieCutterContextDict = NewType("CookieCutterContextDict", Dict[str, str])
 
 
 def _configparser_from_path(cfg_path: Path) -> ConfigParser:
@@ -38,7 +41,7 @@ class CookieCutterContext(abc.ABC):
         self.target_path = target_path
 
     @abc.abstractmethod
-    def read(self) -> Dict[str, str]:
+    def read(self) -> CookieCutterContextDict:
         """Retrieve the context.
 
         If the target file doesn't exist, :class:`FileNotFoundError`
@@ -72,11 +75,11 @@ class ScaraplateConf(CookieCutterContext):
         super().__init__(target_path)
         self.scaraplate_conf = target_path / ".scaraplate.conf"
 
-    def read(self) -> Dict[str, str]:
+    def read(self) -> CookieCutterContextDict:
         configparser = _configparser_from_path(self.scaraplate_conf)
         context_configparser = dict(configparser).get(self.section_name)
         context = dict(context_configparser or {})
-        return context
+        return CookieCutterContextDict(context)
 
     def __str__(self):
         return f"{self.scaraplate_conf}"
@@ -103,11 +106,11 @@ class SetupCfg(CookieCutterContext):
         super().__init__(target_path)
         self.setup_cfg = target_path / "setup.cfg"
 
-    def read(self) -> Dict[str, str]:
+    def read(self) -> CookieCutterContextDict:
         configparser = _configparser_from_path(self.setup_cfg)
         context_configparser = dict(configparser).get(self.section_name)
         context = dict(context_configparser or {})
-        return context
+        return CookieCutterContextDict(context)
 
     def __str__(self):
         return f"{self.setup_cfg}"

--- a/src/scaraplate/strategies.py
+++ b/src/scaraplate/strategies.py
@@ -15,6 +15,7 @@ Sample ``scaraplate.yaml`` excerpt:
         strategy: mypackage.mymodule.MyPackageJson
         config:
           my_key: True
+      "src/{{ cookiecutter.myvariable }}.md": scaraplate.strategies.IfMissing
 
 
 The strategy should be an importable Python class which implements

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,17 @@
 from pathlib import Path
 
+import jinja2.exceptions
 import pytest
 
 import scaraplate.strategies
-from scaraplate.config import ScaraplateYaml, StrategyNode, get_scaraplate_yaml
-from scaraplate.cookiecutter import ScaraplateConf, SetupCfg
+from scaraplate.config import (
+    ScaraplateYamlOptions,
+    ScaraplateYamlStrategies,
+    StrategyNode,
+    get_scaraplate_yaml_options,
+    get_scaraplate_yaml_strategies,
+)
+from scaraplate.cookiecutter import CookieCutterContextDict, ScaraplateConf, SetupCfg
 from scaraplate.gitremotes import GitHub
 
 
@@ -13,12 +20,43 @@ from scaraplate.gitremotes import GitHub
     [
         (
             """
+git_remote_type: scaraplate.gitremotes.GitHub
+""",
+            ScaraplateYamlOptions(
+                git_remote_type=GitHub, cookiecutter_context_type=ScaraplateConf
+            ),
+        ),
+        (
+            """
+cookiecutter_context_type: scaraplate.cookiecutter.SetupCfg
+""",
+            ScaraplateYamlOptions(
+                git_remote_type=None, cookiecutter_context_type=SetupCfg
+            ),
+        ),
+    ],
+)
+def test_get_scaraplate_yaml_options_valid(
+    tempdir_path: Path, yaml_text, expected
+) -> None:
+    (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
+    scaraplate_yaml_options = get_scaraplate_yaml_options(tempdir_path)
+    assert scaraplate_yaml_options == expected
+
+
+@pytest.mark.parametrize(
+    "yaml_text, cookiecutter_context_dict, expected",
+    [
+        # Basic syntax:
+        (
+            """
 default_strategy: scaraplate.strategies.Overwrite
 strategies_mapping:
   Jenkinsfile: scaraplate.strategies.TemplateHash
   'some/nested/setup.py': scaraplate.strategies.TemplateHash
 """,
-            ScaraplateYaml(
+            {},
+            ScaraplateYamlStrategies(
                 default_strategy=StrategyNode(
                     strategy=scaraplate.strategies.Overwrite, config={}
                 ),
@@ -30,10 +68,9 @@ strategies_mapping:
                         strategy=scaraplate.strategies.TemplateHash, config={}
                     ),
                 },
-                git_remote_type=None,
-                cookiecutter_context_type=ScaraplateConf,
             ),
         ),
+        # Extended syntax (with config):
         (
             """
 default_strategy:
@@ -49,7 +86,8 @@ strategies_mapping:
     config:
       some_key: True
 """,
-            ScaraplateYaml(
+            {},
+            ScaraplateYamlStrategies(
                 default_strategy=StrategyNode(
                     strategy=scaraplate.strategies.Overwrite, config={"some_key": True}
                 ),
@@ -62,56 +100,45 @@ strategies_mapping:
                         config={"some_key": True},
                     ),
                 },
-                git_remote_type=None,
-                cookiecutter_context_type=ScaraplateConf,
             ),
         ),
+        # Jinja2 filenames and globs:
         (
             """
-git_remote_type: scaraplate.gitremotes.GitHub
 default_strategy: scaraplate.strategies.Overwrite
 strategies_mapping:
-  Jenkinsfile: scaraplate.strategies.TemplateHash
+  '*.txt': scaraplate.strategies.IfMissing
+  'src/{{ cookiecutter.file1 }}': scaraplate.strategies.TemplateHash
+  'src/{{ cookiecutter.file2 }}': scaraplate.strategies.IfMissing
 """,
-            ScaraplateYaml(
+            {"file1": "zzz.py", "file2": "aaa.py"},
+            ScaraplateYamlStrategies(
                 default_strategy=StrategyNode(
                     strategy=scaraplate.strategies.Overwrite, config={}
                 ),
                 strategies_mapping={
-                    "Jenkinsfile": StrategyNode(
+                    "*.txt": StrategyNode(
+                        strategy=scaraplate.strategies.IfMissing, config={}
+                    ),
+                    "src/aaa.py": StrategyNode(
+                        strategy=scaraplate.strategies.IfMissing, config={}
+                    ),
+                    "src/zzz.py": StrategyNode(
                         strategy=scaraplate.strategies.TemplateHash, config={}
-                    )
+                    ),
                 },
-                git_remote_type=GitHub,
-                cookiecutter_context_type=ScaraplateConf,
-            ),
-        ),
-        (
-            """
-cookiecutter_context_type: scaraplate.cookiecutter.SetupCfg
-default_strategy: scaraplate.strategies.Overwrite
-strategies_mapping:
-  Jenkinsfile: scaraplate.strategies.TemplateHash
-""",
-            ScaraplateYaml(
-                default_strategy=StrategyNode(
-                    strategy=scaraplate.strategies.Overwrite, config={}
-                ),
-                strategies_mapping={
-                    "Jenkinsfile": StrategyNode(
-                        strategy=scaraplate.strategies.TemplateHash, config={}
-                    )
-                },
-                git_remote_type=None,
-                cookiecutter_context_type=SetupCfg,
             ),
         ),
     ],
 )
-def test_get_scaraplate_yaml_valid(tempdir_path: Path, yaml_text, expected) -> None:
+def test_get_scaraplate_yaml_strategies_valid(
+    tempdir_path: Path, yaml_text, cookiecutter_context_dict, expected
+) -> None:
     (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
-    scaraplate_yaml = get_scaraplate_yaml(tempdir_path)
-    assert scaraplate_yaml == expected
+    scaraplate_yaml_strategies = get_scaraplate_yaml_strategies(
+        tempdir_path, cookiecutter_context_dict
+    )
+    assert scaraplate_yaml_strategies == expected
 
 
 @pytest.mark.parametrize(
@@ -128,7 +155,7 @@ def test_get_scaraplate_yaml_valid(tempdir_path: Path, yaml_text, expected) -> N
     ],
 )
 @pytest.mark.parametrize("mutation_target", ["default_strategy", "strategies_mapping"])
-def test_get_scaraplate_yaml_invalid_strategies(
+def test_get_scaraplate_yaml_strategies_invalid(
     tempdir_path: Path, cls: str, mutation_target: str
 ) -> None:
     classes = dict(
@@ -144,7 +171,27 @@ strategies_mapping:
 """
     (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
     with pytest.raises(ValueError):
-        get_scaraplate_yaml(tempdir_path)
+        get_scaraplate_yaml_strategies(tempdir_path, CookieCutterContextDict({}))
+
+
+@pytest.mark.parametrize(
+    "key, cookiecutter_context_dict",
+    [
+        ("'{{ cookiecutter.missingkey }}'", {"anotherkey": "42"}),
+        ("'{{ somevar }}'", {"somavar": "42"}),  # doesn't start with `cookiecutter.`
+    ],
+)
+def test_get_scaraplate_yaml_strategies_invalid_keys(
+    tempdir_path: Path, key, cookiecutter_context_dict
+) -> None:
+    yaml_text = f"""
+default_strategy: scaraplate.strategies.Overwrite
+strategies_mapping:
+  {key}: scaraplate.strategies.Overwrite
+"""
+    (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
+    with pytest.raises(jinja2.exceptions.UndefinedError):
+        get_scaraplate_yaml_strategies(tempdir_path, cookiecutter_context_dict)
 
 
 @pytest.mark.parametrize(
@@ -158,16 +205,15 @@ strategies_mapping:
         "42",
     ],
 )
-def test_get_scaraplate_yaml_invalid_git_remotes(tempdir_path: Path, cls: str) -> None:
+def test_get_scaraplate_yaml_options_invalid_git_remotes(
+    tempdir_path: Path, cls: str
+) -> None:
     yaml_text = f"""
 git_remote_type: {cls}
-default_strategy: scaraplate.strategies.Overwrite
-strategies_mapping:
-  Jenkinsfile: scaraplate.strategies.Overwrite
 """
     (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
     with pytest.raises(ValueError):
-        get_scaraplate_yaml(tempdir_path)
+        get_scaraplate_yaml_options(tempdir_path)
 
 
 @pytest.mark.parametrize(
@@ -181,15 +227,12 @@ strategies_mapping:
         "42",
     ],
 )
-def test_get_scaraplate_yaml_invalid_cookiecutter_context(
+def test_get_scaraplate_yaml_options_invalid_cookiecutter_context(
     tempdir_path: Path, cls: str
 ) -> None:
     yaml_text = f"""
 cookiecutter_context_type: {cls}
-default_strategy: scaraplate.strategies.Overwrite
-strategies_mapping:
-  Jenkinsfile: scaraplate.strategies.Overwrite
 """
     (tempdir_path / "scaraplate.yaml").write_text(yaml_text)
     with pytest.raises(ValueError):
-        get_scaraplate_yaml(tempdir_path)
+        get_scaraplate_yaml_options(tempdir_path)


### PR DESCRIPTION
This is an alternative implementation of #6.

The goal is to allow using jinja2 with cookiecutter variables in the strategies_mapping dict.

The key difference from #6 is that `ScaraplateYaml` has been split to two parts: one which is read before calling cookiecutter (`ScaraplateYamlOptions`), and one which is called after (`ScaraplateYamlStrategies`). This allows to keep these structures immutable.

