### PR TITLE
Fix windows path handling in rollup

### DIFF
--- a/src/scaraplate/rollup.py
+++ b/src/scaraplate/rollup.py
@@ -85,8 +85,8 @@ def rollup(
         cookiecutter_config = cookiecutter_config_path / "cookiecutterrc.yaml"
         cookiecutter_config.write_text(
             f"""
-cookiecutters_dir: "{cookiecutter_config_path / 'cookiecutters'}"
-replay_dir: "{cookiecutter_config_path / 'replay'}"
+cookiecutters_dir: "{(cookiecutter_config_path.resolve() / 'cookiecutters').as_posix()}"
+replay_dir: "{(cookiecutter_config_path.resolve() / 'replay').as_posix()}"
 """
         )
 


### PR DESCRIPTION
This pull request fixes an issue when running scaraplate on Windows.
Without it, scaraplate writes the following into the cookiecutterrc.yaml:
```
cookiecutters_dir: "C:\Users\JOHN~1.ZIE\AppData\Local\Temp\tmpcpc6nruf\cookiecutter_home\cookiecutters"
replay_dir: "C:\Users\JOHN~1.ZIE\AppData\Local\Temp\tmpcpc6nruf\cookiecutter_home\replay"
```
which would result in the following error:
```
Traceback (most recent call last):
  File "c:\users\john.zielke\venvs\test\lib\site-packages\cookiecutter\config.py", line 63, in get_config
    yaml_dict = yaml.safe_load(file_handle)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\__init__.py", line 81, in load
    return loader.get_single_data()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\composer.py", line 64, in compose_node
    if self.check_event(AliasEvent):
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\parser.py", line 98, in check_event
    self.current_event = self.state()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\parser.py", line 449, in parse_block_mapping_value
    if not self.check_token(KeyToken, ValueToken, BlockEndToken):
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 116, in check_token
    self.fetch_more_tokens()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 251, in fetch_more_tokens
    return self.fetch_double()
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 655, in fetch_double
    self.fetch_flow_scalar(style='"')
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 666, in fetch_flow_scalar
    self.tokens.append(self.scan_flow_scalar(style))
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 1149, in scan_flow_scalar
    chunks.extend(self.scan_flow_scalar_non_spaces(double, start_mark))
  File "c:\users\john.zielke\venvs\test\lib\site-packages\yaml\scanner.py", line 1213, in scan_flow_scalar_non_spaces
    raise ScannerError("while scanning a double-quoted scalar", start_mark,
yaml.scanner.ScannerError: while scanning a double-quoted scalar
  in "C:\Users\JOHN~1.ZIE\AppData\Local\Temp\tmp1dtg6g_7\cookiecutter_home\cookiecutterrc.yaml", line 2, column 20
expected escape sequence of 8 hexadecimal numbers, but found 's'
  in "C:\Users\JOHN~1.ZIE\AppData\Local\Temp\tmp1dtg6g_7\cookiecutter_home\cookiecutterrc.yaml", line 2, column 25

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "c:\programdata\miniconda3\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\programdata\miniconda3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\john.zielke\VEnvs\test\Scripts\scaraplate.exe\__main__.py", line 7, in <module>
  File "c:\users\john.zielke\venvs\test\lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\john.zielke\venvs\test\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\scaraplate\__main__.py", line 66, in rollup
    _rollup(
  File "c:\users\john.zielke\venvs\test\lib\site-packages\scaraplate\rollup.py", line 114, in rollup
    cookiecutter(
  File "c:\users\john.zielke\venvs\test\lib\site-packages\cookiecutter\main.py", line 64, in cookiecutter
    config_dict = get_user_config(
  File "c:\users\john.zielke\venvs\test\lib\site-packages\cookiecutter\config.py", line 104, in get_user_config
    return get_config(config_file)
  File "c:\users\john.zielke\venvs\test\lib\site-packages\cookiecutter\config.py", line 65, in get_config
    raise InvalidConfiguration(
cookiecutter.exceptions.InvalidConfiguration: Unable to parse YAML file C:\Users\JOHN~1.ZIE\AppData\Local\Temp\tmp1dtg6g_7\cookiecutter_home\cookiecutterrc.yaml.
```
This PR fixes that by: Resolving the path before writing it into the yaml file (i.e. making it absolute and resolving "variables") and by using `.as_posix()` to make it a linux style path (which still works with python, but it does not contain backslashes, which are interpreted as escape characters in the yaml on load).
